### PR TITLE
Add docker-credential-helper for ecr-login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAMESPACE = connaisseur
-IMAGE := $(shell yq e '.deployment.image' helm/values.yaml)
+IMAGE := "900876714356.dkr.ecr.us-east-2.amazonaws.com/connaisseur:dev"
 COSIGN_VERSION = 1.4.1
 
 .PHONY: all docker install unistall upgrade annihilate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,11 @@ FROM base
 
 WORKDIR /app
 
-# Harden image
+RUN apk add docker-credential-ecr-login # necessary for deployments in AWS EKS to use IRSA permissions
+
+RUN mkdir -p /.ecr/log # not necessary, but INFO 'error' messages pop up complaining about not being able to create it
+RUN chmod 0755 /usr/bin/docker-credential-ecr-login
+
 COPY docker/harden.sh /
 RUN sh /harden.sh && rm /harden.sh
 
@@ -38,6 +42,8 @@ COPY --from=builder /install /usr/local
 COPY --from=cosign_loader /go/cosign/cosign-linux-amd64 /app/cosign/cosign
 COPY connaisseur /app/connaisseur
 
+
+RUN adduser connaisseur -H -u 10001 -D
 USER 10001:20001
 
 LABEL maintainer="Philipp Belitz <philipp.belitz@securesystems.de>"


### PR DESCRIPTION
docker-credential-helper is needed for accessing credentials from IRSA.
Adding this utility reduces overhead in implementing a sidecar to
refresh the Docker Login Credentials for AWS ECR

relevant upstream issues with documented workarounds can be found:
- https://github.com/sse-secure-systems/connaisseur/issues/390
- https://github.com/sse-secure-systems/connaisseur/issues/352

Changes:
- create name for user
- make docker-credential-helper executable for user

<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->
Fixes #

## Description

<!--- Provide a short description of the PR: why? how? -->

## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

