### PR TITLE
create home dir for connaisseur user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=cosign_loader /go/cosign/cosign-linux-amd64 /app/cosign/cosign
 COPY connaisseur /app/connaisseur
 
 
-RUN adduser connaisseur -H -u 10001 -D
+RUN adduser connaisseur -u 10001 -D
 USER 10001:20001
 
 LABEL maintainer="Philipp Belitz <philipp.belitz@securesystems.de>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- Reference respective issue if it exists -->


## Description
Fixes issue seen deploying connaisseur in EKS cluster after creating the `connaisseur` named user
```
8dc085d86750e94c492c9c84475; RETURNCODE: 1; STDOUT: ; STDERR: log: failed to create directory: mkdir /home/connaisseur: permission deniedlog: failed to create directory: mkdir /home/connaisseur: 
```
<!--- Provide a short description of the PR: why? how? -->


## Checklist
<!--- Feel free to reach out if help on any items in the checklist is needed -->

- [ ] PR is rebased to/aimed at branch `develop`
- [ ] PR follows [Contributing Guide](../docs/CONTRIBUTING.md)
- [ ] Added tests (if necessary)
- [ ] Extended README/Documentation (if necessary)
- [ ] Adjusted versions of image and Helm chart in `values.yaml` and `Chart.yaml` (if necessary)

